### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,8 +36,8 @@ jobs:
           $newTag = "v" + ($newVersion -join ".")
           git tag $newTag
           "New version: $newTag"
-          echo "::set-output name=previous_tag::$currentTag"
-          echo "::set-output name=new_tag::$newTag"
+          echo "previous_tag=$currentTag" >> $GITHUB_OUTPUT
+          echo "new_tag=$newTag" >> $GITHUB_OUTPUT
       
       - name: Push version tag
         uses: ad-m/github-push-action@master
@@ -69,7 +69,7 @@ jobs:
           } else {
             $changelog = ""
           }
-          echo "::set-output name=changelog::$changelog"
+          echo "changelog=$changelog" >> $GITHUB_OUTPUT
         
       - name: Create Github Release
         id: create_release


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


